### PR TITLE
feat: run migrations automatically

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,13 @@ COPY . .
 # Install PHP dependencies
 RUN composer install --no-interaction --prefer-dist --optimize-autoloader
 
+# Copy entrypoint script
+COPY docker/entrypoint.sh /usr/local/bin/entrypoint.sh
+RUN chmod +x /usr/local/bin/entrypoint.sh
+
+# Set entrypoint
+ENTRYPOINT ["entrypoint.sh"]
+
 # Expose port 9000 and start php-fpm server
 EXPOSE 9000
 CMD ["php-fpm"]

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ docker-compose up -d
 ```
 
 O comando acima iniciará a aplicação juntamente com os serviços de banco de dados MySQL e Redis.
+As migrações do banco de dados serão executadas automaticamente na inicialização do contêiner.
 
 ## Licença
 

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -e
+
+# Run database migrations automatically
+until php artisan migrate --force; do
+  echo "Waiting for database to be ready..."
+  sleep 5
+done
+
+exec "$@"


### PR DESCRIPTION
## Summary
- run pending migrations automatically on container startup
- document automatic migration execution

## Testing
- `composer test` *(fails: require vendor/autoload.php)*
- `composer install` *(fails: Class App\Services\WhatsAppService located in ./app/Services/WhatsappAppService.php does not comply with psr-4 autoloading standard)*

------
https://chatgpt.com/codex/tasks/task_b_68a4b621184c83299c938a8dadbff5e5