### PR TITLE
Restrict price management to admins and fix balance lookup

### DIFF
--- a/app/Http/Middleware/EnsureUserIsAdmin.php
+++ b/app/Http/Middleware/EnsureUserIsAdmin.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class EnsureUserIsAdmin
+{
+    /**
+     * Handle an incoming request.
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        $user = $request->user();
+
+        if (! $user || ! $user->is_admin) {
+            return response()->json([
+                'message' => 'Acesso negado',
+            ], 403);
+        }
+
+        return $next($request);
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -2,14 +2,12 @@
 
 namespace App\Models;
 
-use Illuminate\Contracts\Auth\MustVerifyEmail;
-use Illuminate\Support\Str;
-use App\Models\Transactions;
-use Laravel\Sanctum\HasApiTokens;
-use Illuminate\Notifications\Notifiable;
 use Illuminate\Database\Eloquent\Concerns\HasUuids;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
+use Illuminate\Notifications\Notifiable;
+use Illuminate\Support\Str;
+use Laravel\Sanctum\HasApiTokens;
 
 class User extends Authenticatable
 {
@@ -20,14 +18,14 @@ class User extends Authenticatable
 
     public function transaction(string $type, float $amount)
     {
-        if (!in_array($type, ['credit', 'debit'])) {
+        if (! in_array($type, ['credit', 'debit'])) {
             throw new \InvalidArgumentException("Tipo de transação inválido: $type");
         }
 
         // Cria a transação
         $transaction = $this->transactions()->create([
             'type' => $type,
-            'amount' => $amount
+            'amount' => $amount,
         ]);
 
         // Atualiza o saldo
@@ -43,7 +41,17 @@ class User extends Authenticatable
     }
 
     /** @use HasFactory<\Database\Factories\UserFactory> */
-    use HasApiTokens, HasFactory, Notifiable, HasUuids;
+    use HasApiTokens, HasFactory, HasUuids, Notifiable;
+
+    /**
+     * Indicates if the IDs are auto-incrementing.
+     */
+    public $incrementing = false;
+
+    /**
+     * The data type of the primary key ID.
+     */
+    protected $keyType = 'string';
 
     /**
      * The attributes that are mass assignable.
@@ -57,9 +65,8 @@ class User extends Authenticatable
         'cellphone',
         'bearer_apibrasil',
         'is_admin',
-        'balance', 
+        'balance',
     ];
-
 
     /**
      * The attributes that should be hidden for serialization.
@@ -85,8 +92,7 @@ class User extends Authenticatable
         ];
     }
 
-
-    //TESTE
+    // TESTE
     protected static function boot()
     {
         parent::boot();

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -12,7 +12,11 @@ return Application::configure(basePath: dirname(__DIR__))
         health: '/up',
     )
     ->withMiddleware(function (Middleware $middleware): void {
-         $middleware->append(\App\Http\Middleware\ForceJsonResponse::class);
+        $middleware->alias([
+            'admin' => \App\Http\Middleware\EnsureUserIsAdmin::class,
+        ]);
+
+        $middleware->append(\App\Http\Middleware\ForceJsonResponse::class);
     })
     ->withExceptions(function (Exceptions $exceptions): void {
         //

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,12 +1,12 @@
 <?php
 
-use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\AuthController;
-use App\Http\Controllers\UsersController;
 use App\Http\Controllers\PricesController;
 use App\Http\Controllers\RequestsController;
 use App\Http\Controllers\TransactionsController;
+use App\Http\Controllers\UsersController;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Route;
 
 // rota de autenticação simples
 Route::post('/register', [AuthController::class, 'register']);
@@ -16,7 +16,7 @@ Route::post('/login', [AuthController::class, 'login'])->name('login');
 Route::middleware('auth:sanctum')->group(function () {
 
     // informações do usuário logado
-    Route::get('/user', fn(Request $request) => $request->user());
+    Route::get('/user', fn (Request $request) => $request->user());
     Route::get('/profile', [AuthController::class, 'profile']);
     Route::post('/logout', [AuthController::class, 'logout']);
 
@@ -28,9 +28,8 @@ Route::middleware('auth:sanctum')->group(function () {
     Route::post('/add-balance', [TransactionsController::class, 'addBalance']);
     Route::post('/users/{id}/add-balance', [TransactionsController::class, 'addBalanceToUser']);
 
-
-    // preços
-    Route::apiResource('prices', PricesController::class);
+    // preços - acesso restrito a administradores
+    Route::middleware('admin')->apiResource('prices', PricesController::class);
 
     // consultas padronizadas → RequestsController::default
     Route::controller(RequestsController::class)->group(function () {
@@ -39,36 +38,31 @@ Route::middleware('auth:sanctum')->group(function () {
         Route::any('/consult/{name}', 'default')->name('request_default');
 
         Route::prefix('whatsapp')->group(function () {
-            Route::post('{action}', fn(Request $req, $action) => app(RequestsController::class)->default($req, "whatsapp/$action"));
+            Route::post('{action}', fn (Request $req, $action) => app(RequestsController::class)->default($req, "whatsapp/$action"));
         });
 
         Route::post('/correios/{name}', 'default');
 
         Route::prefix('geolocation')->group(function () {
-            Route::post('{action}', fn(Request $req, $action) => app(RequestsController::class)->default($req, "geolocation/$action"));
+            Route::post('{action}', fn (Request $req, $action) => app(RequestsController::class)->default($req, "geolocation/$action"));
         });
 
         Route::prefix('weather')->group(function () {
-            Route::post('{action}', fn(Request $req, $action) => app(RequestsController::class)->default($req, "weather/$action"));
+            Route::post('{action}', fn (Request $req, $action) => app(RequestsController::class)->default($req, "weather/$action"));
         });
 
-        Route::any('/cep/{action?}', fn(Request $req, $action = null) =>
-            app(RequestsController::class)->default($req, $action ? "cep/" . trim($action, '/') : "cep")
+        Route::any('/cep/{action?}', fn (Request $req, $action = null) => app(RequestsController::class)->default($req, $action ? 'cep/'.trim($action, '/') : 'cep')
         )->where('action', '.*');
 
-        Route::post('/geomatrix', fn(Request $req) => app(RequestsController::class)->default($req, 'geomatrix/distance'));
+        Route::post('/geomatrix', fn (Request $req) => app(RequestsController::class)->default($req, 'geomatrix/distance'));
 
-        Route::any('/translate/{action?}', fn(Request $req, $action = null) =>
-            app(RequestsController::class)->default($req, $action ? "translate/" . trim($action, '/') : "translate")
+        Route::any('/translate/{action?}', fn (Request $req, $action = null) => app(RequestsController::class)->default($req, $action ? 'translate/'.trim($action, '/') : 'translate')
         )->where('action', '.*');
 
-        Route::any('/ddd/{action?}', fn(Request $req, $action = null) =>
-            app(RequestsController::class)->default($req, $action ? "ddd/" . trim($action, '/') : "ddd")
+        Route::any('/ddd/{action?}', fn (Request $req, $action = null) => app(RequestsController::class)->default($req, $action ? 'ddd/'.trim($action, '/') : 'ddd')
         )->where('action', '.*');
 
-        Route::any('/database/{action?}', fn(Request $req, $action = null) =>
-            app(RequestsController::class)->default($req, $action ? "database/" . trim($action, '/') : "database")
+        Route::any('/database/{action?}', fn (Request $req, $action = null) => app(RequestsController::class)->default($req, $action ? 'database/'.trim($action, '/') : 'database')
         )->where('action', '.*');
     });
 });
-


### PR DESCRIPTION
## Summary
- allow only admin users to access price CRUD endpoints
- add middleware to verify admin status
- fix balance top-up lookup by using string UUID keys in User model

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_b_68a638e180c88327973ec88c89ef88e8