### PR TITLE
feat: allow admins to promote users

### DIFF
--- a/routes/api.php
+++ b/routes/api.php
@@ -1,12 +1,12 @@
 <?php
 
-use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\AuthController;
-use App\Http\Controllers\UsersController;
 use App\Http\Controllers\PricesController;
 use App\Http\Controllers\RequestsController;
 use App\Http\Controllers\TransactionsController;
+use App\Http\Controllers\UsersController;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Route;
 
 // rota de autenticação simples
 Route::post('/register', [AuthController::class, 'register']);
@@ -16,18 +16,18 @@ Route::post('/login', [AuthController::class, 'login'])->name('login');
 Route::middleware('auth:sanctum')->group(function () {
 
     // informações do usuário logado
-    Route::get('/user', fn(Request $request) => $request->user());
+    Route::get('/user', fn (Request $request) => $request->user());
     Route::get('/profile', [AuthController::class, 'profile']);
     Route::post('/logout', [AuthController::class, 'logout']);
 
     // atualizar usuário
     Route::put('/users/{id}', [UsersController::class, 'update']);
+    Route::post('/users/{id}/make-admin', [UsersController::class, 'makeAdmin']);
 
     // transações e saldo
     Route::get('/transactions', [TransactionsController::class, 'index']);
     Route::post('/add-balance', [TransactionsController::class, 'addBalance']);
     Route::post('/users/{id}/add-balance', [TransactionsController::class, 'addBalanceToUser']);
-
 
     // preços
     Route::apiResource('prices', PricesController::class);
@@ -39,36 +39,31 @@ Route::middleware('auth:sanctum')->group(function () {
         Route::any('/consult/{name}', 'default')->name('request_default');
 
         Route::prefix('whatsapp')->group(function () {
-            Route::post('{action}', fn(Request $req, $action) => app(RequestsController::class)->default($req, "whatsapp/$action"));
+            Route::post('{action}', fn (Request $req, $action) => app(RequestsController::class)->default($req, "whatsapp/$action"));
         });
 
         Route::post('/correios/{name}', 'default');
 
         Route::prefix('geolocation')->group(function () {
-            Route::post('{action}', fn(Request $req, $action) => app(RequestsController::class)->default($req, "geolocation/$action"));
+            Route::post('{action}', fn (Request $req, $action) => app(RequestsController::class)->default($req, "geolocation/$action"));
         });
 
         Route::prefix('weather')->group(function () {
-            Route::post('{action}', fn(Request $req, $action) => app(RequestsController::class)->default($req, "weather/$action"));
+            Route::post('{action}', fn (Request $req, $action) => app(RequestsController::class)->default($req, "weather/$action"));
         });
 
-        Route::any('/cep/{action?}', fn(Request $req, $action = null) =>
-            app(RequestsController::class)->default($req, $action ? "cep/" . trim($action, '/') : "cep")
+        Route::any('/cep/{action?}', fn (Request $req, $action = null) => app(RequestsController::class)->default($req, $action ? 'cep/'.trim($action, '/') : 'cep')
         )->where('action', '.*');
 
-        Route::post('/geomatrix', fn(Request $req) => app(RequestsController::class)->default($req, 'geomatrix/distance'));
+        Route::post('/geomatrix', fn (Request $req) => app(RequestsController::class)->default($req, 'geomatrix/distance'));
 
-        Route::any('/translate/{action?}', fn(Request $req, $action = null) =>
-            app(RequestsController::class)->default($req, $action ? "translate/" . trim($action, '/') : "translate")
+        Route::any('/translate/{action?}', fn (Request $req, $action = null) => app(RequestsController::class)->default($req, $action ? 'translate/'.trim($action, '/') : 'translate')
         )->where('action', '.*');
 
-        Route::any('/ddd/{action?}', fn(Request $req, $action = null) =>
-            app(RequestsController::class)->default($req, $action ? "ddd/" . trim($action, '/') : "ddd")
+        Route::any('/ddd/{action?}', fn (Request $req, $action = null) => app(RequestsController::class)->default($req, $action ? 'ddd/'.trim($action, '/') : 'ddd')
         )->where('action', '.*');
 
-        Route::any('/database/{action?}', fn(Request $req, $action = null) =>
-            app(RequestsController::class)->default($req, $action ? "database/" . trim($action, '/') : "database")
+        Route::any('/database/{action?}', fn (Request $req, $action = null) => app(RequestsController::class)->default($req, $action ? 'database/'.trim($action, '/') : 'database')
         )->where('action', '.*');
     });
 });
-

--- a/tests/Feature/AdminPromoteUserTest.php
+++ b/tests/Feature/AdminPromoteUserTest.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class AdminPromoteUserTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_admin_can_promote_user_to_admin(): void
+    {
+        $admin = User::create([
+            'name' => 'Admin',
+            'email' => 'admin@example.com',
+            'password' => bcrypt('password'),
+            'cellphone' => '123456789',
+            'balance' => 0,
+        ]);
+
+        $user = User::create([
+            'name' => 'User',
+            'email' => 'user@example.com',
+            'password' => bcrypt('password'),
+            'cellphone' => '987654321',
+            'balance' => 0,
+        ]);
+
+        $response = $this->actingAs($admin, 'sanctum')
+            ->postJson('/api/users/'.$user->id.'/make-admin');
+
+        $response->assertStatus(200)
+            ->assertJson([
+                'message' => 'Usuário promovido a administrador com sucesso',
+            ]);
+
+        $this->assertDatabaseHas('users', [
+            'id' => $user->id,
+            'is_admin' => true,
+        ]);
+    }
+
+    public function test_non_admin_cannot_promote_user_to_admin(): void
+    {
+        $admin = User::create([
+            'name' => 'Admin',
+            'email' => 'admin2@example.com',
+            'password' => bcrypt('password'),
+            'cellphone' => '111111111',
+            'balance' => 0,
+        ]);
+
+        $nonAdmin = User::create([
+            'name' => 'NonAdmin',
+            'email' => 'nonadmin@example.com',
+            'password' => bcrypt('password'),
+            'cellphone' => '222222222',
+            'balance' => 0,
+        ]);
+
+        $target = User::create([
+            'name' => 'Target',
+            'email' => 'target@example.com',
+            'password' => bcrypt('password'),
+            'cellphone' => '333333333',
+            'balance' => 0,
+        ]);
+
+        $response = $this->actingAs($nonAdmin, 'sanctum')
+            ->postJson('/api/users/'.$target->id.'/make-admin');
+
+        $response->assertStatus(403);
+
+        $this->assertDatabaseHas('users', [
+            'id' => $target->id,
+            'is_admin' => false,
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary
- allow admins to promote other users to administrators
- add API route to expose promotion endpoint
- cover admin promotion with feature tests

## Testing
- `php artisan test`

------
https://chatgpt.com/codex/tasks/task_b_68a63ebe53fc8327bd87370e1c635cd7