### PR TITLE
Restrict prices CRUD to admins

### DIFF
--- a/app/Http/Middleware/EnsureUserIsAdmin.php
+++ b/app/Http/Middleware/EnsureUserIsAdmin.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+
+class EnsureUserIsAdmin
+{
+    public function handle(Request $request, Closure $next)
+    {
+        if (! $request->user() || ! $request->user()->is_admin) {
+            return response()->json(['message' => 'Apenas administradores podem acessar.'], 403);
+        }
+
+        return $next($request);
+    }
+}
+

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -13,6 +13,9 @@ return Application::configure(basePath: dirname(__DIR__))
     )
     ->withMiddleware(function (Middleware $middleware): void {
          $middleware->append(\App\Http\Middleware\ForceJsonResponse::class);
+         $middleware->alias([
+             'admin' => \App\Http\Middleware\EnsureUserIsAdmin::class,
+         ]);
     })
     ->withExceptions(function (Exceptions $exceptions): void {
         //


### PR DESCRIPTION
## Summary
- add middleware to ensure only admins access price CRUD
- wire up middleware alias in application bootstrap

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_b_68a74633143883278956a217bcf00201