### PR TITLE
Define admin middleware to fix missing class error

### DIFF
--- a/app/Http/Middleware/EnsureUserIsAdmin.php
+++ b/app/Http/Middleware/EnsureUserIsAdmin.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class EnsureUserIsAdmin
+{
+    /**
+     * Handle an incoming request.
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        $user = $request->user();
+        if (! $user || ! $user->is_admin) {
+            return response()->json([
+                'message' => 'Apenas administradores podem realizar essa ação',
+            ], 403);
+        }
+
+        return $next($request);
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -12,7 +12,10 @@ return Application::configure(basePath: dirname(__DIR__))
         health: '/up',
     )
     ->withMiddleware(function (Middleware $middleware): void {
-         $middleware->append(\App\Http\Middleware\ForceJsonResponse::class);
+        $middleware->append(\App\Http\Middleware\ForceJsonResponse::class);
+        $middleware->alias([
+            'admin' => \App\Http\Middleware\EnsureUserIsAdmin::class,
+        ]);
     })
     ->withExceptions(function (Exceptions $exceptions): void {
         //


### PR DESCRIPTION
## Summary
- add middleware to verify authenticated user is admin
- register `admin` middleware alias

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_b_68a75296a080832780749999339a38a6