### PR TITLE
Validate unique email on user update

### DIFF
--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -62,6 +62,19 @@ class UsersController extends Controller
 
             $data = $request->only(['name', 'email', 'cellphone', 'password', 'bearer_apibrasil']);
 
+            // valida se o e-mail já está em uso por outro usuário
+            if (! empty($data['email']) && $data['email'] !== $user->email) {
+                $exists = User::where('email', $data['email'])
+                    ->where('id', '!=', $user->id)
+                    ->exists();
+
+                if ($exists) {
+                    return response()->json([
+                        'error' => 'E-mail já está em uso',
+                    ], 422);
+                }
+            }
+
             // Se veio senha, criptografa
             if (! empty($data['password'])) {
                 $data['password'] = bcrypt($data['password']);

--- a/tests/Feature/UserUpdateEmailTest.php
+++ b/tests/Feature/UserUpdateEmailTest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class UserUpdateEmailTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_user_cannot_update_email_to_existing_email(): void
+    {
+        $user1 = User::create([
+            'name' => 'User1',
+            'email' => 'user1@example.com',
+            'password' => bcrypt('password'),
+            'cellphone' => '111111111',
+            'balance' => 0,
+        ]);
+
+        $user2 = User::create([
+            'name' => 'User2',
+            'email' => 'user2@example.com',
+            'password' => bcrypt('password'),
+            'cellphone' => '222222222',
+            'balance' => 0,
+        ]);
+
+        $response = $this->actingAs($user2, 'sanctum')
+            ->putJson('/api/users/' . $user2->id, [
+                'email' => 'user1@example.com',
+            ]);
+
+        $response->assertStatus(422)
+            ->assertJson([
+                'error' => 'E-mail já está em uso',
+            ]);
+
+        $this->assertDatabaseHas('users', [
+            'id' => $user2->id,
+            'email' => 'user2@example.com',
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary
- prevent updating a user email to an existing one
- add feature test covering duplicate email update scenario

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_b_68a760de3ae08327bb41f3efd9df20c8