### PR TITLE
fix: install dependencies on startup if vendor missing

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,6 +1,11 @@
 #!/bin/sh
 set -e
 
+# Install dependencies if not already present
+if [ ! -f vendor/autoload.php ]; then
+  composer install --no-interaction --prefer-dist --optimize-autoloader
+fi
+
 # Espera DB e roda migrate + seed
 until php artisan migrate --force; do
   echo "Waiting for database to be ready..."


### PR DESCRIPTION
## Summary
- install composer dependencies from entrypoint when vendor is missing

## Testing
- `php artisan test`

------
https://chatgpt.com/codex/tasks/task_b_68a76deca2808327be33976dc598b7b2