### PR TITLE
Run price seeder on build

### DIFF
--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -24,7 +24,8 @@ class DatabaseSeeder extends Seeder
         // ]);
 
         $this->call([
-            UserSeeder::class
+            UserSeeder::class,
+            PriceSeeder::class,
         ]);
         
     }

--- a/database/seeders/PriceSeeder.php
+++ b/database/seeders/PriceSeeder.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use App\Models\Prices;
+
+class PriceSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        $prices = [
+            ['name' => 'sendText', 'value_buy' => 1.5, 'value_sell' => 2],
+            ['name' => 'whatsapp/sendFile', 'value_buy' => 1.5, 'value_sell' => 2],
+            ['name' => 'whatsapp/sendFile64', 'value_buy' => 1.5, 'value_sell' => 2],
+            ['name' => 'whatsapp/sendVideo', 'value_buy' => 1.5, 'value_sell' => 2],
+            ['name' => 'whatsapp/sendImages', 'value_buy' => 1.5, 'value_sell' => 2],
+            ['name' => 'cep', 'value_buy' => 1.5, 'value_sell' => 2],
+            ['name' => 'cidades', 'value_buy' => 1.5, 'value_sell' => 2],
+            ['name' => 'geomatrix', 'value_buy' => 1.6, 'value_sell' => 2.1],
+            ['name' => 'ddd', 'value_buy' => 1.5, 'value_sell' => 2],
+            ['name' => 'translate', 'value_buy' => 1.5, 'value_sell' => 2],
+            ['name' => 'database', 'value_buy' => 1.5, 'value_sell' => 2],
+            ['name' => 'cnpj', 'value_buy' => 1.5, 'value_sell' => 2],
+            ['name' => 'cpf', 'value_buy' => 1.6, 'value_sell' => 2.1],
+        ];
+
+        foreach ($prices as $price) {
+            Prices::firstOrCreate(
+                ['name' => $price['name']],
+                ['value_buy' => $price['value_buy'], 'value_sell' => $price['value_sell']]
+            );
+        }
+    }
+}
+

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -7,4 +7,6 @@ until php artisan migrate --force; do
   sleep 5
 done
 
+php artisan db:seed --force
+
 exec "$@"


### PR DESCRIPTION
## Summary
- add PriceSeeder with default price values
- seed prices during container startup
- register PriceSeeder in DatabaseSeeder

## Testing
- `APP_KEY=$(php -r "echo 'base64:'.base64_encode(random_bytes(32));") composer test`

------
https://chatgpt.com/codex/tasks/task_b_68a7763328348327bb96216278322297