### PR TITLE
Generate env file automatically on docker-compose build

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,6 +1,12 @@
 #!/bin/sh
 set -e
 
+# Gera arquivo .env caso não exista
+if [ ! -f .env ]; then
+  cp .env.example .env
+  php artisan key:generate
+fi
+
 # Espera DB e roda migrate + seed
 until php artisan migrate --force; do
   echo "Waiting for database to be ready..."


### PR DESCRIPTION
## Summary
- auto-create `.env` from example and generate app key when container starts

## Testing
- `composer test`
- `shellcheck docker/entrypoint.sh` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a786d896748327af95233f4eadf5e3