### PR TITLE
Add gateway server and API listing endpoints

### DIFF
--- a/app/Http/Controllers/GatewayController.php
+++ b/app/Http/Controllers/GatewayController.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Http;
+
+class GatewayController extends Controller
+{
+    /**
+     * Return list of servers from API Brasil gateway.
+     */
+    public function servers(Request $request)
+    {
+        $user = Auth::user();
+
+        $headers = [
+            'Authorization' => 'Bearer ' . $user->bearer_apibrasil,
+            'Content-Type' => 'application/json',
+        ];
+
+        $deviceToken = $request->header('DeviceToken');
+        if ($deviceToken) {
+            $headers['DeviceToken'] = $deviceToken;
+        }
+
+        $response = Http::withHeaders($headers)
+            ->get('https://gateway.apibrasil.io/api/v2/servers');
+
+        return response()->json($response->json(), $response->status());
+    }
+
+    /**
+     * Return list of APIs associated with the authenticated user.
+     */
+    public function apis(Request $request)
+    {
+        $user = Auth::user();
+
+        $headers = [
+            'Authorization' => 'Bearer ' . $user->bearer_apibrasil,
+            'Content-Type' => 'application/json',
+        ];
+
+        $deviceToken = $request->header('DeviceToken');
+        if ($deviceToken) {
+            $headers['DeviceToken'] = $deviceToken;
+        }
+
+        $response = Http::withHeaders($headers)
+            ->get('https://gateway.apibrasil.io/api/v2/apis');
+
+        return response()->json($response->json(), $response->status());
+    }
+}
+

--- a/routes/api.php
+++ b/routes/api.php
@@ -5,6 +5,7 @@ use App\Http\Controllers\PricesController;
 use App\Http\Controllers\RequestsController;
 use App\Http\Controllers\TransactionsController;
 use App\Http\Controllers\UsersController;
+use App\Http\Controllers\GatewayController;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 
@@ -28,6 +29,10 @@ Route::middleware('auth:sanctum')->group(function () {
     Route::get('/transactions', [TransactionsController::class, 'index']);
     Route::post('/add-balance', [TransactionsController::class, 'addBalance']);
     Route::post('/users/{id}/add-balance', [TransactionsController::class, 'addBalanceToUser']);
+
+    // gateway information
+    Route::get('/gateway/servers', [GatewayController::class, 'servers']);
+    Route::get('/gateway/apis', [GatewayController::class, 'apis']);
 
     // preços - acesso restrito a administradores
     Route::middleware('admin')->apiResource('prices', PricesController::class);


### PR DESCRIPTION
## Summary
- add controller to fetch API Brasil servers and user APIs
- expose new `/gateway/servers` and `/gateway/apis` routes

## Testing
- `php artisan test` *(fails: MissingAppKeyException)*

------
https://chatgpt.com/codex/tasks/task_b_68a8ac2c37d083278e1c64867aaa32c2