### PR TITLE
Add device search endpoint and dynamic routing

### DIFF
--- a/app/Http/Controllers/DevicesController.php
+++ b/app/Http/Controllers/DevicesController.php
@@ -61,4 +61,34 @@ class DevicesController extends Controller
 
         return response()->json($response->json(), $response->status());
     }
+
+    public function search(Request $request, string $device)
+    {
+        $user = Auth::user();
+        $secretKey = request()->header('SecretKey'); // string|array|null
+
+        if (is_array($secretKey)) {
+            $secretKey = $secretKey[0] ?? null;
+        }
+        $secretKey = $secretKey ? trim($secretKey) : null;
+
+        if ($secretKey) {
+            $headers[] = 'SecretKey: ' . $secretKey;
+        }
+
+        if (!$user || !$user->bearer_apibrasil) {
+            return response()->json([
+                'error' => true,
+                'message' => 'Token API Brasil não configurado',
+            ], 400);
+        }
+
+        $response = Http::withHeaders([
+            'Content-Type' => 'application/json',
+            'Authorization' => 'Bearer ' . $user->bearer_apibrasil,
+            'SecretKey' => $secretKey,
+        ])->post("{$this->baseUrl}/devices/{$device}/search", $request->all());
+
+        return response()->json($response->json(), $response->status());
+    }
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -33,8 +33,11 @@ Route::middleware('auth:sanctum')->group(function () {
     Route::post('/users/{id}/add-balance', [TransactionsController::class, 'addBalanceToUser']);
 
     // devices
-    Route::get('/devices', [DevicesController::class, 'index']);
-    Route::post('/devices/store', [DevicesController::class, 'store']);
+    Route::prefix('devices')->controller(DevicesController::class)->group(function () {
+        Route::get('/', 'index');
+        Route::post('store', 'store');
+        Route::post('{device}/search', 'search');
+    });
 
     // gateway information
     Route::get('/gateway/servers', [GatewayController::class, 'servers']);

--- a/tests/Feature/DevicesTest.php
+++ b/tests/Feature/DevicesTest.php
@@ -62,5 +62,31 @@ class DevicesTest extends TestCase
                 'devices' => [],
             ]);
     }
+
+    public function test_search_updates_device(): void
+    {
+        Http::fake([
+            'https://gateway.apibrasil.io/api/v2/devices/123/search' => Http::response([
+                'device' => ['device_token' => '123'],
+            ], 200),
+        ]);
+
+        $user = User::create([
+            'name' => 'User3',
+            'email' => 'user3@example.com',
+            'password' => bcrypt('password'),
+            'cellphone' => '555555555',
+            'balance' => 0,
+            'bearer_apibrasil' => 'token',
+        ]);
+
+        $response = $this->actingAs($user, 'sanctum')
+            ->postJson('/api/devices/123/search');
+
+        $response->assertStatus(200)
+            ->assertJson([
+                'device' => ['device_token' => '123'],
+            ]);
+    }
 }
 


### PR DESCRIPTION
## Summary
- add search method to DevicesController to update devices
- group device routes and expose dynamic `/devices/{device}/search` endpoint
- cover device search with feature tests

## Testing
- `./vendor/bin/phpunit --filter=DevicesTest`


------
https://chatgpt.com/codex/tasks/task_b_68a8d605d6b48327bc8d41341b468809