### PR TITLE
fix: forward destroy payload to API

### DIFF
--- a/app/Http/Controllers/DevicesController.php
+++ b/app/Http/Controllers/DevicesController.php
@@ -14,7 +14,7 @@ class DevicesController extends Controller
     {
         $user = Auth::user();
 
-        if (!$user || !$user->bearer_apibrasil) {
+        if (! $user || ! $user->bearer_apibrasil) {
             return response()->json([
                 'error' => true,
                 'message' => 'Token API Brasil não configurado',
@@ -23,7 +23,7 @@ class DevicesController extends Controller
 
         $response = Http::withHeaders([
             'Content-Type' => 'application/json',
-            'Authorization' => 'Bearer ' . $user->bearer_apibrasil,
+            'Authorization' => 'Bearer '.$user->bearer_apibrasil,
         ])->get("{$this->baseUrl}/devices");
 
         return response()->json($response->json(), $response->status());
@@ -43,10 +43,10 @@ class DevicesController extends Controller
 
         // Se existir, adiciona no header de saída
         if ($secretKey) {
-            $headers[] = 'SecretKey: ' . $secretKey;
+            $headers[] = 'SecretKey: '.$secretKey;
         }
 
-        if (!$user || !$user->bearer_apibrasil) {
+        if (! $user || ! $user->bearer_apibrasil) {
             return response()->json([
                 'error' => true,
                 'message' => 'Token API Brasil não configurado',
@@ -55,18 +55,18 @@ class DevicesController extends Controller
 
         $response = Http::withHeaders([
             'Content-Type' => 'application/json',
-            'Authorization' => 'Bearer ' . $user->bearer_apibrasil,
+            'Authorization' => 'Bearer '.$user->bearer_apibrasil,
             'SecretKey' => $secretKey,
         ])->post("{$this->baseUrl}/devices/store", $request->all());
 
         return response()->json($response->json(), $response->status());
     }
 
-    public function search(Request $request,)
+    public function search(Request $request)
     {
         $user = Auth::user();
 
-        if (!$user || !$user->bearer_apibrasil) {
+        if (! $user || ! $user->bearer_apibrasil) {
             return response()->json([
                 'error' => true,
                 'message' => 'Token API Brasil não configurado',
@@ -75,7 +75,7 @@ class DevicesController extends Controller
 
         $response = Http::withHeaders([
             'Content-Type' => 'application/json',
-            'Authorization' => 'Bearer ' . $user->bearer_apibrasil,
+            'Authorization' => 'Bearer '.$user->bearer_apibrasil,
         ])->post("{$this->baseUrl}/devices/search", $request->all());
 
         return response()->json($response->json(), $response->status());
@@ -85,7 +85,7 @@ class DevicesController extends Controller
     {
         $user = Auth::user();
 
-        if (!$user || !$user->bearer_apibrasil) {
+        if (! $user || ! $user->bearer_apibrasil) {
             return response()->json([
                 'error' => true,
                 'message' => 'Token API Brasil não configurado',
@@ -94,8 +94,8 @@ class DevicesController extends Controller
 
         $response = Http::withHeaders([
             'Content-Type' => 'application/json',
-            'Authorization' => 'Bearer ' . $user->bearer_apibrasil,
-        ])->delete("{$this->baseUrl}/devices/destroy");
+            'Authorization' => 'Bearer '.$user->bearer_apibrasil,
+        ])->delete("{$this->baseUrl}/devices/destroy", $request->all());
 
         return response()->json($response->json(), $response->status());
     }


### PR DESCRIPTION
## Summary
- ensure device destroy request forwards body payload to remote API

## Testing
- `composer test` *(fails: No application encryption key has been specified)*

------
https://chatgpt.com/codex/tasks/task_b_68a8dc0c55ac8327b795bcf96fc295fb